### PR TITLE
Allow non-integer id formats such as hex

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "procurios/omnikassa2-sdk",
+  "name": "opensdks/omnikassa2-sdk",
   "description": "Rabobank OmniKassa SDK",
   "license": "proprietary",
   "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "opensdks/omnikassa2-sdk",
+  "name": "procurios/omnikassa2-sdk",
   "description": "Rabobank OmniKassa SDK",
   "license": "proprietary",
   "minimum-stability": "dev",

--- a/src/model/response/PaymentCompletedResponse.php
+++ b/src/model/response/PaymentCompletedResponse.php
@@ -52,7 +52,6 @@ class PaymentCompletedResponse extends SignedResponse
     public static function createInstance($orderID, $status, $signature, SigningKey $signingKey)
     {
         //Sanitize input
-        $orderID = preg_replace('/[^0-9]/', '', $orderID);
         $status = preg_replace('/[^A-Z_]/', '', $status);
         $signature = preg_replace('/[^0-9a-f]/', '', $signature);
 

--- a/test/model/response/PaymentCompletedResponseTest.php
+++ b/test/model/response/PaymentCompletedResponseTest.php
@@ -30,4 +30,13 @@ class PaymentCompletedResponseTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('1', $paymentCompletedResponse->getOrderID());
         $this->assertEquals('IN_PROGRESS', $paymentCompletedResponse->getStatus());
     }
+
+    public function testIsValidReturnsTrueForNonIntegerIds()
+    {
+        $signingKey = new SigningKey('secret');
+        $paymentCompletedResponse = PaymentCompletedResponse::createInstance('866a13038dd88f851fa3556a3b7d2da515018a95', 'COMPLETED', 'f29bc3142089ba67f3ff62a9b4b94fd2c923f50adbd752430ae480f70727863de750aa05d2dbae1bd0adb0c380135cbac34062b121cb051fbf9193a6a1c016fe', $signingKey);
+        $this->assertNotFalse($paymentCompletedResponse);
+        $this->assertEquals('866a13038dd88f851fa3556a3b7d2da515018a95', $paymentCompletedResponse->getOrderID());
+        $this->assertEquals('COMPLETED', $paymentCompletedResponse->getStatus());
+    }
 }


### PR DESCRIPTION
Hey there,
Rabobank seems to not have accounted for shops using non-numeric ids. I don't think it makes sense to doubly-verify that id matches the id the signature is calculated for; the calculation itself already does that. All we want from the payment completed response is to make sure the orderID we sent over the wire is the same that comes back, whether it's 123, '1ab' or 'cow'. What do you think?
Kind regards,
Pim Elshoff
Procurios