### PR TITLE
Issue with multiplication of decimal amounts

### DIFF
--- a/src/model/Money.php
+++ b/src/model/Money.php
@@ -35,8 +35,9 @@ class Money implements JsonSerializable, SignatureDataProvider
      */
     public static function fromDecimal($currency, $amount)
     {
-        $roundedAmount = round($amount, 2);
-        return self::fromCents($currency, $roundedAmount * 100);
+        $roundedAmount = round($roundedAmount * 100, 2);
+        
+        return self::fromCents($currency, $roundedAmount);
     }
 
     /**


### PR DESCRIPTION
In PHP 7.4 is need round for sure entire result, in other case there are possible small differences for some decimal values after multiplication, concrete example: 69.85 * 100 = 6984.999999999999 => intval() => 6984. It's caused with some decimal amounts, which can't be represented accurately.