### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "minimum-stability": "dev",
   "require": {
     "php": ">= 5.4",
-    "netresearch/jsonmapper": "^0.11.0",
+    "netresearch/jsonmapper": "^4.0.0",
     "guzzlehttp/guzzle": "5.3.1|^6.3.0|^7.0"
   },
   "require-dev": {


### PR DESCRIPTION
Update the JSON mapper requirement to version 4, which is the most current release and supports PHP 8. With the old version running PHP 8 generates the following fatal error:
`Compile Error: Array and string offset access syntax with curly braces is no longer supported`

Updating to version 4, fixes this problem.